### PR TITLE
Setup background color for series

### DIFF
--- a/GraceChurch/src/content-single/ContentSingle.js
+++ b/GraceChurch/src/content-single/ContentSingle.js
@@ -83,13 +83,19 @@ class ContentSingle extends PureComponent {
     const content = data.node || {};
 
     const { theme = {}, id } = content;
-
+    const colors = get(theme, 'colors') || {};
+    const { primary } = colors;
     return (
       <ThemeMixin
-        mixin={{
-          type: get(theme, 'type'),
-          colors: get(theme, 'colors'),
-        }}
+        mixin={
+          content.theme
+            ? {
+                colors: {
+                  ...(primary ? { primary } : {}),
+                },
+              }
+            : {}
+        }
       >
         <InteractWhenLoadedConnected
           isLoading={loading}

--- a/apollos-api/src/data/ContentItem.js
+++ b/apollos-api/src/data/ContentItem.js
@@ -1,7 +1,8 @@
 import ApollosConfig from '@apollosproject/config';
 import { ContentItem } from '@apollosproject/data-connector-rock';
 import sanitizeHTML from '@apollosproject/data-connector-rock/lib/sanitize-html';
-import { get } from 'lodash';
+import { get, flatten } from 'lodash';
+import Color from 'color';
 
 const {
   resolver: baseResolver,
@@ -21,6 +22,38 @@ class dataSource extends ContentItemDataSource {
     }
     return cursor.orderBy('StartDateTime', 'desc');
   };
+
+  async getTheme({ id, attributeValues: { backgroundColor } = {} }) {
+    const primary = get(backgroundColor, 'value');
+    const type = Color(primary).luminosity() > 0.5 ? 'LIGHT' : 'DARK';
+
+    const theme = {
+      type,
+      colors: {
+        primary,
+      },
+    };
+
+    if (!primary && id) {
+      const parentItemsCursor = await this.getCursorByChildContentItemId(id);
+      if (parentItemsCursor) {
+        const parentItems = await parentItemsCursor.get();
+        if (parentItems.length) {
+          const parentThemes = flatten(
+            await Promise.all(parentItems.map((i) => this.getTheme(i)))
+          ).filter((v) => v);
+          if (parentThemes && parentThemes.length) {
+            return parentThemes[0];
+          }
+        }
+      }
+    }
+    // if there's still no primary color set in the CMS, we want to return a null theme so that
+    // the front end uses its default theme:
+    if (!theme.colors.primary) return null;
+
+    return theme;
+  }
 }
 
 const newResolvers = {
@@ -28,6 +61,8 @@ const newResolvers = {
     sanitizeHTML(
       `${content}\n${get(attributeValues, 'mobileDiscussionGuide.value', '')}`
     ),
+  theme: (root, input, { dataSources }) =>
+    dataSources.ContentItem.getTheme(root),
 };
 
 const contentItemTypes = Object.keys(ApollosConfig.ROCK_MAPPINGS.CONTENT_ITEM);

--- a/apollos-api/src/data/theme/index.js
+++ b/apollos-api/src/data/theme/index.js
@@ -1,5 +1,4 @@
 import { gql } from 'apollo-server';
-import randomColor from 'randomcolor';
 
 import colorScalarType from './colorScalarType';
 
@@ -26,31 +25,6 @@ export const schema = gql`
 `;
 
 export const resolver = {
-  Theme: {
-    type: () => 'DARK', // todo: infer theme type from data
-    colors: (seed) => {
-      // todo: don't generate a random theme :)
-      const baseColors = randomColor({ seed, count: 2, luminosity: 'bright' });
-      return {
-        primary: baseColors[0],
-        secondary: baseColors[1],
-        screen: randomColor({
-          seed,
-          hue: baseColors[0],
-          luminosity: 'dark',
-        }),
-        paper: randomColor({
-          seed,
-          hue: baseColors[1],
-          luminosity: 'dark',
-        }),
-        alert: randomColor({
-          seed,
-          hue: 'red',
-        }),
-      };
-    },
-  },
   Color: colorScalarType,
 };
 


### PR DESCRIPTION
This PR takes advantage of the new rock custom attribute in `Podcast Series` called `backgroundColor`. When you add a hex color you should see that color used anywhere `theme.colors.primary` is used in a `ContentItem`. Below is an example of passing in the alert color as the primary color.
![image](https://user-images.githubusercontent.com/2528817/84433535-09065000-abf4-11ea-8255-404c95eb45ee.png)=
![image](https://user-images.githubusercontent.com/2528817/84433509-00ae1500-abf4-11ea-90a8-4ec78243ee3f.png)
![image](https://user-images.githubusercontent.com/2528817/84433566-18859900-abf4-11ea-90e8-404294417c7e.png)

