### PR TITLE
Change app name on device

### DIFF
--- a/GraceChurch/android/app/src/main/res/values/strings.xml
+++ b/GraceChurch/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">GraceChurch</string>
+    <string name="app_name">Grace</string>
 </resources>

--- a/GraceChurch/android/app/src/main/res/values/strings.xml
+++ b/GraceChurch/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Grace</string>
+    <string name="app_name">Grace CC</string>
 </resources>

--- a/GraceChurch/ios/GraceChurch/Info.plist
+++ b/GraceChurch/ios/GraceChurch/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>Grace CC</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This PR changes the name of the app that shows on your device from "Grace Church" to "Grace CC".

[Basecamp](https://3.basecamp.com/3926363/buckets/17723932/todos/2800656778)

Test - uninstall the app from your device and then rebuild to see the name change

|iOS|Android|
|---|---|
||![Screenshot_1593710237](https://user-images.githubusercontent.com/52924611/86390905-e1d8f680-bc66-11ea-98be-3e5d5f1bbda0.png)|