### PR TITLE
fix: updates to 40 day challenge logic

### DIFF
--- a/apollos-api/src/data/ContentItem.js
+++ b/apollos-api/src/data/ContentItem.js
@@ -3,7 +3,13 @@ import { ContentItem } from '@apollosproject/data-connector-rock';
 import sanitizeHTML from 'sanitize-html';
 import { get } from 'lodash';
 import moment from 'moment';
-import { isSunday, previousSunday, format, nextSunday } from 'date-fns';
+import {
+  isSunday,
+  previousSunday,
+  formatISO,
+  startOfToday,
+  nextSunday,
+} from 'date-fns';
 
 const {
   resolver: baseResolver,
@@ -186,27 +192,20 @@ class dataSource extends ContentItemDataSource {
       .orderBy('StartDateTime', 'desc');
   }
 
-  getWeeklyGrace = async (limit) => {
-    const sunday = isSunday(Date.now())
-      ? Date.now()
-      : previousSunday(Date.now());
-    return (
-      this.request()
-        .andFilter('ContentChannelId eq 16')
-        .andFilter(
-          `StartDateTime ge datetime'${format(sunday, 'yyyy-MM-dd')}T00:00:00'`
-        )
-        .andFilter(
-          `StartDateTime lt datetime'${format(
-            nextSunday(Date.now()),
-            'yyyy-MM-dd'
-          )}T00:00:00'`
-        )
-        // .andFilter(this.LIVE_CONTENT())
-        .top(limit)
-        .get()
-    );
-  };
+  getWeeklyGrace = async (limit) =>
+    this.request()
+      .andFilter('ContentChannelId eq 16')
+      .andFilter(
+        `((StartDateTime ge datetime'${formatISO(
+          isSunday(startOfToday())
+            ? startOfToday()
+            : previousSunday(startOfToday())
+        )}') and (StartDateTime lt datetime'${formatISO(
+          nextSunday(startOfToday())
+        )}'))`
+      )
+      .top(limit)
+      .get();
 
   getActiveLiveStreamContent = async () => {
     const { LiveStream } = this.context.dataSources;


### PR DESCRIPTION
This PR is an attempt to get their 40 Day Challenge feed to work as expected. I changed the filter logic slightly to show weekly content from Monday to Sunday (grabbing fresh content on Monday of each week. I tested this by manually subtracting weeks using the `sub` helper in `date-fns`.

|2 Weeks Ago|1 Week Ago|This Week|
|---|---|---|
|![Screen Shot 2022-04-21 at 10 52 06 AM](https://user-images.githubusercontent.com/72768221/164501955-dbeac7b2-0edd-4ac7-9d26-e1ec1cd7f703.png)|![Screen Shot 2022-04-21 at 10 52 33 AM](https://user-images.githubusercontent.com/72768221/164501994-f6048f9a-6b78-4474-a9ca-89b85a2d9850.png)|![Simulator Screen Shot - iPhone 13 - 2022-04-21 at 10 50 32](https://user-images.githubusercontent.com/72768221/164502041-a096f66d-2011-435c-a5f0-b846dfa87e0b.png)|