### PR TITLE
chore: updates to persona feed for sorting and channels

### DIFF
--- a/apollos-api/config.yml
+++ b/apollos-api/config.yml
@@ -217,7 +217,7 @@ HOME_FEATURES:
          arguments:
            limit: 6
      subtitle: Upcoming
-     type: Herolist
+     type: VerticalCardList
    - subtitle: Stay Connected
      heroAlgorithms:
        - type: SINGLE_IMAGE_CARD
@@ -267,7 +267,7 @@ TABS:
           arguments:
             limit: 6
       subtitle: Upcoming
-      type: HeroList
+      type: VerticalCardList
       primaryAction:
         action: OPEN_CHANNEL
         title: 'View All'

--- a/apollos-api/config.yml
+++ b/apollos-api/config.yml
@@ -213,9 +213,10 @@ HOME_FEATURES:
      subtitle: Featured
      type: VerticalCardList
    - algorithms:
-       - type: CAMPAIGN_ITEMS
+       - type: PERSONA_FEED
          arguments:
            limit: 6
+           contentChannelIds: [15,26] # This is hardcoded to accept 2 contentChannelIds...see ContentItem.js
      subtitle: Upcoming
      type: VerticalCardList
    - subtitle: Stay Connected
@@ -263,9 +264,10 @@ TABS:
       subtitle: Today's Message Outline
       type: VerticalCardList
     - algorithms:
-        - type: CAMPAIGN_ITEMS
+        - type: PERSONA_FEED
           arguments:
             limit: 6
+            contentChannelIds: [15,26]
       subtitle: Upcoming
       type: VerticalCardList
       primaryAction:

--- a/apollos-api/src/data/ActionAlgorithms.js
+++ b/apollos-api/src/data/ActionAlgorithms.js
@@ -23,7 +23,6 @@ class dataSource extends ActionAlgorithmDataSource {
     return items.map((item, i) => ({
       id: `${item.id}${i}`,
       title: item.title,
-      subtitle: get(item, 'contentChannel.name'),
       relatedNode: { ...item, __type: ContentItem.resolveType(item) },
       image: ContentItem.getCoverImage(item),
       action: 'READ_CONTENT',

--- a/apollos-api/src/data/ActionAlgorithms.js
+++ b/apollos-api/src/data/ActionAlgorithms.js
@@ -8,12 +8,15 @@ const {
 } = ActionAlgorithm;
 
 class dataSource extends ActionAlgorithmDataSource {
-  async personaFeedAlgorithm({ contentChannelId }) {
+  async personaFeedAlgorithm({ limit = 6, contentChannelIds = [] }) {
     const { ContentItem, Feature } = this.context.dataSources;
     Feature.setCacheHint({ scope: 'PRIVATE' });
 
     // Get the first three persona items.
-    const personaFeed = await ContentItem.byPersonaFeed(3, contentChannelId);
+    const personaFeed = await ContentItem.byPersonaFeed(
+      limit,
+      contentChannelIds
+    );
     const items = await personaFeed.expand('ContentChannel').get();
 
     // Map them into specific actions.

--- a/apollos-api/src/data/ContentItem.js
+++ b/apollos-api/src/data/ContentItem.js
@@ -15,7 +15,8 @@ const { ROCK_MAPPINGS } = ApollosConfig;
 
 class dataSource extends ContentItemDataSource {
   // Generates feed based on persons dataview membership
-  byPersonaFeed = async (first, contentChannelId) => {
+  // This is hardcoded to accept 2 contentChannelIds
+  byPersonaFeed = async (limit, contentChannelIds) => {
     const {
       dataSources: { Persona },
     } = this.context;
@@ -44,9 +45,14 @@ class dataSource extends ContentItemDataSource {
     )
       .andFilter(this.LIVE_CONTENT())
       .andFilter(
-        contentChannelId ? `ContentChannelId eq ${contentChannelId}` : ''
+        contentChannelIds[1]
+          ? `ContentChannelId eq ${
+              contentChannelIds[0]
+            } or ContentChannelId eq ${contentChannelIds[1]}`
+          : ''
       )
-      .top(first)
+      .top(limit)
+      .orderBy('StartDateTime', 'desc')
       .orderBy('Priority', 'desc');
   };
 

--- a/apollos-api/src/data/ContentItem.js
+++ b/apollos-api/src/data/ContentItem.js
@@ -52,7 +52,6 @@ class dataSource extends ContentItemDataSource {
           : ''
       )
       .top(limit)
-      .orderBy('StartDateTime', 'desc')
       .orderBy('Priority', 'desc');
   };
 


### PR DESCRIPTION
This PR updates a couple of features to new types in addition to a tweak to the Persona Feed. The Persona Feed now supports 2 channels and is sorted by Priority, then StartDate. 

| How it looks in Rock | How it looks in App |
|---|---|
|<img width="1556" alt="Screen Shot 2022-06-30 at 3 53 20 PM" src="https://user-images.githubusercontent.com/72768221/176786053-395d4682-fec6-4321-afed-14c68b3915d9.png"> | <img width="804" alt="Screen Shot 2022-06-30 at 3 53 10 PM" src="https://user-images.githubusercontent.com/72768221/176786064-9345588d-7870-4232-8450-6262a02526ec.png"> |

Based on Priority, this order in app is correct.
 